### PR TITLE
Added Worksheet.use_start_page_number.

### DIFF
--- a/xlwt/Worksheet.py
+++ b/xlwt/Worksheet.py
@@ -175,6 +175,7 @@ class Worksheet(object):
         self.__print_not_colour = 0
         self.__print_draft = 0
         self.__print_notes = 0
+        self.__use_start_page_number = 1
         self.__print_notes_at_end = 0
         self.__print_omit_errors = 0
         self.__print_hres = 0x012C # 300 dpi
@@ -901,6 +902,25 @@ class Worksheet(object):
 
     #################################################################
 
+    def set_use_start_page_number(self, value):
+        self.__use_start_page_number = int(value)
+
+    def get_use_start_page_number(self):
+        """Change page numbering logic when printing multiple worksheets.
+
+            Default: True
+            True:  The first page number will be the value of
+                   Worksheet.start_page_number.
+            False: Automatic start page number. The first page of the
+                   second worksheet will be one more than the last page
+                   of the first worksheet. Ignore Worksheet.start_page_number.
+        """
+        return bool(self.__use_start_page_number)
+
+    use_start_page_number = property(get_use_start_page_number, set_use_start_page_number)
+
+    #################################################################
+
     def set_print_notes_at_end(self, value):
         self.__print_notes_at_end = int(value)
 
@@ -1287,7 +1307,7 @@ class Worksheet(object):
         setup_page_options |=  (self.__print_draft & 0x01) << 4
         setup_page_options |=  (self.__print_notes & 0x01) << 5
         setup_page_options |=  (0x00 & 0x01) << 6
-        setup_page_options |=  (0x01 & 0x01) << 7
+        setup_page_options |=  (self.__use_start_page_number & 0x01) << 7
         setup_page_options |=  (self.__print_notes_at_end & 0x01) << 9
         setup_page_options |=  (self.__print_omit_errors & 0x03) << 10
 


### PR DESCRIPTION
Currently, xlwt hardcodes the Worksheet is hardcoded to always use the Worksheet.start_page_number for the first page of the worksheet when &P is in the header or footer.

If you are printing multiple sheets at once, it is nice to have automatic page numbering, so each successive worksheet starts where the last one left off. It is especially confusing since &N in the header or footer will display the total number of pages for all the sheets selected for printing. This can yield three worksheets being printed out with the header "1 of 3", "1 of 3", "1 of 3" instead of "1 of 3", "2 of 3", "3 of 3".

This patch simply adds a new property to override the value in the BIFFRecord.