### PR TITLE
Use more modern utf-8 encoding for source files

### DIFF
--- a/examples/blanks.py
+++ b/examples/blanks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/col_width.py
+++ b/examples/col_width.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 __rev_id__ = """$Id$"""
 

--- a/examples/country.py
+++ b/examples/country.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2007 John Machin
 
 from xlwt import *

--- a/examples/dates.py
+++ b/examples/dates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/format.py
+++ b/examples/format.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/formula_names.py
+++ b/examples/formula_names.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/formulas.py
+++ b/examples/formulas.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/hyperlinks.py
+++ b/examples/hyperlinks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/image.py
+++ b/examples/image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/merged.py
+++ b/examples/merged.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/merged0.py
+++ b/examples/merged0.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/merged1.py
+++ b/examples/merged1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/mini.py
+++ b/examples/mini.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/num_formats.py
+++ b/examples/num_formats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/numbers_demo.py
+++ b/examples/numbers_demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/outline.py
+++ b/examples/outline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/panes.py
+++ b/examples/panes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/panes2.py
+++ b/examples/panes2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: ascii -*-
+# -*- coding: utf-8 -*-
 # portions Copyright (C) 2005 Kiseliov Roman
 
 import xlwt

--- a/examples/row_styles.py
+++ b/examples/row_styles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/row_styles_empty.py
+++ b/examples/row_styles_empty.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 __rev_id__ = """$Id$"""
 

--- a/examples/sst.py
+++ b/examples/sst.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/unicode1.py
+++ b/examples/unicode1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/examples/unicode2.py
+++ b/examples/unicode2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 # Copyright (C) 2005 Kiseliov Roman
 
 from xlwt import *

--- a/xlwt/BIFFRecords.py
+++ b/xlwt/BIFFRecords.py
@@ -1,4 +1,4 @@
-# -*- coding: cp1252 -*-
+# -*- coding: utf-8 -*-
 from struct import pack
 from .UnicodeUtils import upack1, upack2, upack2rt
 from .compat import basestring, unicode, unicode_type, xrange, iteritems
@@ -1728,10 +1728,10 @@ class RefModeRecord(BiffRecord):
     """
     This record is part of the Calculation Settings Block.
     It stores which method is used to show cell addresses in formulas.
-    The “RC” mode uses numeric indexes for rows and columns,
-    i.e. “R(1)C(-1)”, or “R1C1:R2C2”.
-    The “A1” mode uses characters for columns and numbers for rows,
-    i.e. “B1”, or “$A$1:$B$2”.
+    The "RC" mode uses numeric indexes for rows and columns,
+    i.e. "R(1)C(-1)", or "R1C1:R2C2".
+    The "A1" mode uses characters for columns and numbers for rows,
+    i.e. "B1", or "$A$1:$B$2".
 
     Record REFMODE, BIFF2-BIFF8:
 
@@ -1779,7 +1779,7 @@ class DeltaRecord(BiffRecord):
 class SaveRecalcRecord(BiffRecord):
     """
     This record is part of the Calculation Settings Block.
-    It contains the “Recalculate before save” option in
+    It contains the "Recalculate before save" option in
     Excel's calculation settings dialogue.
 
     Record SAVERECALC, BIFF3-BIFF8:
@@ -2445,7 +2445,7 @@ class ExternnameRecord(BiffRecord):
     0       0001H   0 = Standard name; 1 = Built-in name
     1       0002H   0 = Manual link; 1 = Automatic link (DDE links and OLE links only)
     2       0004H   1 = Picture link (DDE links and OLE links only)
-    3       0008H   1 = This is the “StdDocumentName” identifier (DDE links only)
+    3       0008H   1 = This is the "StdDocumentName" identifier (DDE links only)
     4       0010H   1 = OLE link
     14-5    7FE0H   Clipboard format of last successful update (DDE links and OLE links only)
     15      8000H   1 = Iconified picture link (BIFF8 OLE links only)

--- a/xlwt/Bitmap.py
+++ b/xlwt/Bitmap.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1251 -*-
+# -*- coding: utf-8 -*-
 
 #  Portions are Copyright (C) 2005 Roman V. Kiseliov
 #  Portions are Copyright (c) 2004 Evgeny Filatov <fufff@users.sourceforge.net>

--- a/xlwt/Cell.py
+++ b/xlwt/Cell.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from struct import unpack, pack
 from . import BIFFRecords

--- a/xlwt/Column.py
+++ b/xlwt/Column.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from .BIFFRecords import ColInfoRecord
 

--- a/xlwt/CompoundDoc.py
+++ b/xlwt/CompoundDoc.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 import struct
 from .compat import xrange

--- a/xlwt/ExcelFormula.py
+++ b/xlwt/ExcelFormula.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from . import ExcelFormulaParser, ExcelFormulaLexer
 import struct

--- a/xlwt/ExcelFormulaLexer.py
+++ b/xlwt/ExcelFormulaLexer.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from .antlr import EOF, CommonToken as Tok, TokenStream, TokenStreamException
 from . import ExcelFormulaParser

--- a/xlwt/ExcelMagic.py
+++ b/xlwt/ExcelMagic.py
@@ -1,4 +1,4 @@
-# -*- coding: ascii -*-
+# -*- coding: utf-8 -*-
 """
 lots of Excel Magic Numbers
 """

--- a/xlwt/Row.py
+++ b/xlwt/Row.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from decimal import Decimal
 from . import BIFFRecords

--- a/xlwt/Style.py
+++ b/xlwt/Style.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 from . import Formatting
 from .BIFFRecords import NumberFormatRecord, XFRecord, StyleRecord

--- a/xlwt/UnicodeUtils.py
+++ b/xlwt/UnicodeUtils.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 
 '''
 From BIFF8 on, strings are always stored using UTF-16LE  text encoding. The
@@ -34,8 +34,8 @@ Offset  Size    Contents
 [2 or 3] 2      (optional, only if richtext=1) Number of Rich-Text formatting runs (rt)
 [var.]   4      (optional, only if phonetic=1) Size of Asian phonetic settings block (in bytes, sz)
 var.     ln or 
-         2·ln   Character array (8-bit characters or 16-bit characters, dependent on ccompr)
-[var.]   4·rt   (optional, only if richtext=1) List of rt formatting runs 
+         2Â·ln   Character array (8-bit characters or 16-bit characters, dependent on ccompr)
+[var.]   4Â·rt   (optional, only if richtext=1) List of rt formatting runs
 [var.]   sz     (optional, only if phonetic=1) Asian Phonetic Settings Block 
 '''
 

--- a/xlwt/Workbook.py
+++ b/xlwt/Workbook.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 # Record Order in BIFF8
 #   Workbook Globals Substream
 #       BOF Type = workbook globals

--- a/xlwt/Worksheet.py
+++ b/xlwt/Worksheet.py
@@ -1,4 +1,4 @@
-# -*- coding: windows-1252 -*-
+# -*- coding: utf-8 -*-
 #             BOF
 #             UNCALCED
 #             INDEX


### PR DESCRIPTION
Avoids errors like these when processing Django messages with xgettext:
```
xgettext: ./env/lib/python2.7/site-packages/xlwt/Bitmap.py:1: Unknown encoding "windows-1251". Proceeding with ASCII instead.
xgettext: ./env/lib/python2.7/site-packages/xlwt/Cell.py:1: Unknown encoding "windows-1252". Proceeding with ASCII instead.
xgettext: ./env/lib/python2.7/site-packages/xlwt/Column.py:1: Unknown encoding "windows-1252". Proceeding with ASCII instead.
xgettext: ./env/lib/python2.7/site-packages/xlwt/CompoundDoc.py:1: Unknown encoding "windows-1252". Proceeding with ASCII instead.
xgettext: Non-ASCII string at ./env/lib/python2.7/site-packages/xlwt/CompoundDoc.py:209.
          Please specify the source encoding through --from-code.
```