### PR TITLE
Rename [wheel] section to [bdist_wheel] as it is considered legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
-universal=1
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/