### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 .. _Coveralls: https://coveralls.io/r/python-excel/xlwt?branch=master
 
 .. |Docs| image:: https://readthedocs.org/projects/xlwt/badge/?version=latest
-.. _Docs: https://xlwt.readthedocs.org/en/latest/
+.. _Docs: https://xlwt.readthedocs.io/en/latest/
 
 .. |PyPI| image:: https://badge.fury.io/py/xlwt.svg
 .. _PyPI: https://badge.fury.io/py/xlwt
@@ -63,7 +63,7 @@ If these aren't sufficient, please consult the code in the
 examples directory and the source code itself.
 
 The latest documentation can also be found at:
-https://xlwt.readthedocs.org/en/latest/
+https://xlwt.readthedocs.io/en/latest/
 
 Problems?
 =========


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of readthedocs.org. Fix
all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on
> the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.