### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 
 # command to install dependencies

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from xlwt import __VERSION__
 DESCRIPTION = (
     'Library to create spreadsheet files compatible with '
     'MS Excel 97/2000/XP/2003 XLS files, '
-    'on any platform, with Python 2.7, 3.3+'
+    'on any platform, with Python 2.7, 3.4+'
     )
 
 CLASSIFIERS = [
@@ -21,7 +21,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -48,5 +47,6 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(),
     zip_safe=False,
-    include_package_data=True
+    include_package_data=True,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py35, py34, py33, py27, py26
+envlist = py36, py35, py34, py27
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.3 is end of life. It is no longer receiving bug fixes, including for
security issues. Python 3.3 went EOL on 2017-09-29. For additional details on
support Python versions, see:

https://devguide.python.org/#status-of-python-branches

For details on the Python 3.3 release schedule, see:

https://www.python.org/dev/peps/pep-0398/

Removing support for EOL Pythons will reduce testing and maintenance resources.